### PR TITLE
Ensure that migrations are silenced with the SILENT_MIGRATIONS env var

### DIFF
--- a/lib/seed_migration/migrator.rb
+++ b/lib/seed_migration/migrator.rb
@@ -4,6 +4,7 @@ require "pathname"
 module SeedMigration
   class Migrator
     SEEDS_FILE_PATH = Rails.root.join("db", "seeds.rb")
+    STDNULL = File.open(File::NULL, 'w')
 
     def self.data_migration_directory
       Rails.root.join("db", SeedMigration.migrations_path)
@@ -142,7 +143,9 @@ module SeedMigration
       @logger
     end
 
-    def self.set_logger(new_logger = Logger.new($stdout))
+    def self.set_logger(new_logger = nil)
+      output = ENV.fetch("SILENT_MIGRATION", false) ? STDNULL: $stdout
+      new_logger = Logger.new(output)
       @logger = new_logger
     end
 
@@ -158,8 +161,6 @@ module SeedMigration
     end
 
     def announce(text)
-      return if ENV["SILENT_MIGRATION"]
-
       length = [0, 75 - text.length].max
       SeedMigration::Migrator.logger.info "== %s %s" % [text, "=" * length]
     end

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,11 +1,11 @@
-sqlite: &sqlite
+sqlite3: &sqlite3
   adapter: sqlite3
   database: db/<%= Rails.env %>.sqlite3
 
 mysql: &mysql
   adapter: mysql2
   username: root
-  password: 
+  password:
   database: seed-migration-<%= Rails.env %>
 
 postgresql: &postgresql
@@ -19,7 +19,7 @@ defaults: &defaults
   pool: 5
   timeout: 5000
   host: localhost
-  <<: *<%= ENV['DB'] || "postgresql" %>
+  <<: *<%= ENV.fetch('DB', "sqlite3") %>
 
 development:
   <<: *defaults

--- a/spec/dummy/config/database.yml
+++ b/spec/dummy/config/database.yml
@@ -1,11 +1,11 @@
-sqlite3: &sqlite3
+sqlite: &sqlite
   adapter: sqlite3
   database: db/<%= Rails.env %>.sqlite3
 
 mysql: &mysql
   adapter: mysql2
   username: root
-  password:
+  password: 
   database: seed-migration-<%= Rails.env %>
 
 postgresql: &postgresql
@@ -19,7 +19,7 @@ defaults: &defaults
   pool: 5
   timeout: 5000
   host: localhost
-  <<: *<%= ENV.fetch('DB', "sqlite3") %>
+  <<: *<%= ENV['DB'] || "postgresql" %>
 
 development:
   <<: *defaults

--- a/spec/lib/seed_migration/migrator_spec.rb
+++ b/spec/lib/seed_migration/migrator_spec.rb
@@ -151,6 +151,19 @@ describe SeedMigration::Migrator do
         expect(output).to contain(@files.count - 1).occurrences_of(" up ")
         expect(output).to contain(1).occurrences_of(" down ")
       end
+
+      context "when SILENT_MIGRATION is set in the environment" do
+        before { allow(ENV).to receive(:fetch).with("SILENT_MIGRATION", false).and_return("true") }
+
+        it "does not output any statuses" do
+          output = capture_stdout do
+          SeedMigration::Migrator.set_logger
+          SeedMigration::Migrator.display_migrations_status
+        end
+
+        expect(output).not_to contain(@files.count).occurrences_of(" up ")
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Makes the rspec output much cleaner when testing migrations or using migrations in a test